### PR TITLE
added filtering for active customers

### DIFF
--- a/bangazonAPI/api/models/customer.py
+++ b/bangazonAPI/api/models/customer.py
@@ -11,6 +11,7 @@ class Customer(SafeDeleteModel):
 	# date_joined & last_login should be a UNIX timestamp as a string
 	date_joined = models.CharField(max_length=100)
 	last_login = models.CharField(max_length=100)
+	active = models.BooleanField(default=False)
 
 	class Meta:
 		db_table = "customers"

--- a/bangazonAPI/api/views/customer.py
+++ b/bangazonAPI/api/views/customer.py
@@ -10,5 +10,13 @@ class CustomerViewSet(viewsets.ModelViewSet):
 	'''
 	queryset = Customer.objects.all()
 	serializer_class = CustomerSerializer
-	http_method_names = ['get', 'put', 'post']	
+	http_method_names = ['get', 'put', 'post']
 	
+	def get_queryset(self):
+		queryset = Customer.objects.all()
+		active = self.request.GET.get('active')
+		active = active.title() # DO NOT REMOVE THIS LINE! django defaults the query to a lowercase true/false which raises an assertion error
+		if active:
+			queryset = queryset.filter(active=active)
+
+		return queryset

--- a/bangazonAPI/api/views/customer.py
+++ b/bangazonAPI/api/views/customer.py
@@ -15,8 +15,8 @@ class CustomerViewSet(viewsets.ModelViewSet):
 	def get_queryset(self):
 		queryset = Customer.objects.all()
 		active = self.request.GET.get('active')
-		active = active.title() # DO NOT REMOVE THIS LINE! django defaults the query to a lowercase true/false which raises an assertion error
 		if active:
+			active = active.title() # DO NOT REMOVE THIS LINE! django defaults the query to a lowercase true/false which raises an assertion error
 			queryset = queryset.filter(active=active)
 
 		return queryset


### PR DESCRIPTION
Closes ticket #11 

# Changes Made
1. added boolean to customers table
1. overwrote the default queryset method on CustomerViewSet
1. enabled filtering of active or inactive customers

## Steps to test
1. `git fetch --all` & `git checkout activeOrder`
1. delete migrations and database
1. `python3 manage.py makemigrations api` & `python3 manage.py migrate`
1. `python3 manage.py runserver`
1. create a few customers with varying states of active
1. go [here](http://127.0.0.1:8000/customers/?active=false) to see inactive users
1. go [here](http://127.0.0.1:8000/customers/?active=true) to see active users

## Files changed
1. models/customer.py
1. views/customer.py